### PR TITLE
Move raw-loader to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
   "homepage": "https://github.com/FranckFreiburger/vue-pdf#readme",
   "dependencies": {
     "pdfjs-dist": "^2.0.303",
-    "vue-resize-sensor": "^2.0.0"
+    "vue-resize-sensor": "^2.0.0",
+    "raw-loader": "^0.5.1"
   },
   "devDependencies": {
-    "babel-plugin-syntax-dynamic-import": "^6.18.0",
-    "raw-loader": "^0.5.1"
+    "babel-plugin-syntax-dynamic-import": "^6.18.0"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/FranckFreiburger/vue-pdf/issues/57

Tested by moving `raw-loader` to dependencies, removing `package-lock` and reinstalling node modules.
Worked as expected.