### PR TITLE
New canvas on each render

### DIFF
--- a/src/componentFactory.js
+++ b/src/componentFactory.js
@@ -13,13 +13,17 @@ export default function(pdfjsWrapper) {
 					style: 'position: relative'
 				}
 			}, [
-				h('canvas', {
-					style: {
-						display: 'block',
-						width: '100%',
-					},
-					ref:'canvas'
-				}),
+				h('div', {
+					ref: 'canvasParent'
+				}, [
+					h('canvas', {
+						style: {
+							display: 'block',
+							width: '100%',
+						},
+						ref:'canvas'
+					})
+				]),
 				h('div', {
 					class: 'annotationLayer',
 					ref:'annotationLayer'
@@ -58,7 +62,6 @@ export default function(pdfjsWrapper) {
 				this.pdf.loadPage(this.page, this.rotate);
 			},
 			rotate: function() {
-				
 				this.pdf.renderPage(this.rotate);
 			},
 		},
@@ -70,13 +73,15 @@ export default function(pdfjsWrapper) {
 					return;
 
 				// on IE10- canvas height must be set
-				this.$refs.canvas.style.height = this.$refs.canvas.offsetWidth * (this.$refs.canvas.height / this.$refs.canvas.width) + 'px';
-
+				this.pdf.setCanvasHeight(this.pdf.getCanvas().offsetWidth * (this.pdf.getCanvas().height / this.pdf.getCanvas().width) + 'px');
 				// update the page when the resolution is too poor
 				var resolutionScale = this.pdf.getResolutionScale();
 				
 				if ( resolutionScale < 0.85 || resolutionScale > 1.15 )
+				{
 					this.pdf.renderPage(this.rotate);
+				}
+					
 
 				this.$refs.annotationLayer.style.transform = 'scale('+resolutionScale+')';
 			},
@@ -89,7 +94,7 @@ export default function(pdfjsWrapper) {
 		// doc: mounted hook is not called during server-side rendering.
 		mounted: function() {
 
-			this.pdf = new PDFJSWrapper(this.$refs.canvas, this.$refs.annotationLayer, this.$emit.bind(this));
+			this.pdf = new PDFJSWrapper(this.$refs.canvasParent, this.$refs.canvas, this.$refs.annotationLayer, this.$emit.bind(this));
 			
 			this.$on('loaded', function() {
 				
@@ -97,8 +102,7 @@ export default function(pdfjsWrapper) {
 			});
 			
 			this.$on('page-size', function(width, height) {
-				
-				this.$refs.canvas.style.height = this.$refs.canvas.offsetWidth * (height / width) + 'px';
+				this.pdf.setCanvasHeight(this.pdf.getCanvas().offsetWidth  * (height / width) + 'px');
 			});
 			
 			this.pdf.loadDocument(this.src);

--- a/src/componentFactory.js
+++ b/src/componentFactory.js
@@ -16,13 +16,7 @@ export default function(pdfjsWrapper) {
 				h('div', {
 					ref: 'canvasParent'
 				}, [
-					h('canvas', {
-						style: {
-							display: 'block',
-							width: '100%',
-						},
-						ref:'canvas'
-					})
+
 				]),
 				h('div', {
 					class: 'annotationLayer',
@@ -94,7 +88,7 @@ export default function(pdfjsWrapper) {
 		// doc: mounted hook is not called during server-side rendering.
 		mounted: function() {
 
-			this.pdf = new PDFJSWrapper(this.$refs.canvasParent, this.$refs.canvas, this.$refs.annotationLayer, this.$emit.bind(this));
+			this.pdf = new PDFJSWrapper(this.$refs.canvasParent, this.$refs.annotationLayer, this.$emit.bind(this));
 			
 			this.$on('loaded', function() {
 				

--- a/src/pdfjsWrapper.js
+++ b/src/pdfjsWrapper.js
@@ -218,7 +218,7 @@ export default function(PDFJS) {
 			if ( rotate === undefined )
 				rotate = 0;
 
-			canvasElt = canvasElt.cloneNode();
+			canvasElt = canvasElt.cloneNode(true);
 			const previousCanvas = canvasParent.firstChild;
 			if (previousCanvas) {
 				canvasParent.replaceChild(canvasElt, previousCanvas);

--- a/src/pdfjsWrapper.js
+++ b/src/pdfjsWrapper.js
@@ -218,7 +218,6 @@ export default function(PDFJS) {
 			if ( rotate === undefined )
 				rotate = 0;
 
-			const oldCanvas = canvasElt;
 			canvasElt = canvasElt.cloneNode();
 			const previousCanvas = canvasParent.firstChild;
 			if (previousCanvas) {

--- a/src/pdfjsWrapper.js
+++ b/src/pdfjsWrapper.js
@@ -48,12 +48,16 @@ export default function(PDFJS) {
 	}
 
 
-	function PDFJSWrapper(canvasParent, canvasElt, annotationLayerElt, emitEvent) {
+	function PDFJSWrapper(canvasParent, annotationLayerElt, emitEvent) {
 		
 		var pdfDoc = null;
 		var pdfPage = null;
 		var pdfRender = null;
 		var canceling = false;
+		var canvasElt = document.createElement('canvas');
+		canvasElt.style.display = 'block';
+		canvasElt.style.width = '100%';
+		canvasParent.appendChild(canvasElt);
 
 		function clearCanvas() {
 			
@@ -194,9 +198,6 @@ export default function(PDFJS) {
 		}
 		
 		this.renderPage = function(rotate) {
-			const oldCanvas = canvasElt;
-			canvasElt = canvasElt.cloneNode();
-			canvasParent.replaceChild(canvasElt, oldCanvas)
 			if ( pdfRender !== null ) {
 
 				if ( canceling )
@@ -217,7 +218,14 @@ export default function(PDFJS) {
 			if ( rotate === undefined )
 				rotate = 0;
 
-			
+			const oldCanvas = canvasElt;
+			canvasElt = canvasElt.cloneNode();
+			const previousCanvas = canvasParent.firstChild;
+			if (previousCanvas) {
+				canvasParent.replaceChild(canvasElt, previousCanvas);
+			} else {
+				canvasParent.appendChild(canvasElt);
+			}
 
 			var scale = canvasElt.offsetWidth / pdfPage.getViewport(1).width * (window.devicePixelRatio || 1);
 			var viewport = pdfPage.getViewport(scale, rotate);

--- a/src/pdfjsWrapper.js
+++ b/src/pdfjsWrapper.js
@@ -48,7 +48,7 @@ export default function(PDFJS) {
 	}
 
 
-	function PDFJSWrapper(canvasElt, annotationLayerElt, emitEvent) {
+	function PDFJSWrapper(canvasParent, canvasElt, annotationLayerElt, emitEvent) {
 		
 		var pdfDoc = null;
 		var pdfPage = null;
@@ -72,6 +72,14 @@ export default function(PDFJS) {
 				return;
 			pdfDoc.destroy();
 			pdfDoc = null;
+		}
+
+		this.setCanvasHeight = function(h) {
+			canvasElt.style.height = h
+		}
+
+		this.getCanvas = function() {
+			return canvasElt;
 		}
 		
 		this.getResolutionScale = function() {
@@ -186,7 +194,9 @@ export default function(PDFJS) {
 		}
 		
 		this.renderPage = function(rotate) {
-			
+			const oldCanvas = canvasElt;
+			canvasElt = canvasElt.cloneNode();
+			canvasParent.replaceChild(canvasElt, oldCanvas)
 			if ( pdfRender !== null ) {
 
 				if ( canceling )
@@ -206,6 +216,8 @@ export default function(PDFJS) {
 
 			if ( rotate === undefined )
 				rotate = 0;
+
+			
 
 			var scale = canvasElt.offsetWidth / pdfPage.getViewport(1).width * (window.devicePixelRatio || 1);
 			var viewport = pdfPage.getViewport(scale, rotate);
@@ -238,7 +250,6 @@ export default function(PDFJS) {
 
 			pdfRender
 			.then(function() {
-				
 				annotationLayerElt.style.visibility = '';
 				canceling = false;
 				pdfRender = null;


### PR DESCRIPTION
Both the Angular and the React `pdf.js` projects have implemented using a new canvas on each render. This PR does that as well.

From my testing, this PR fixes #73, and may also fix #59.

In my testing and from the discussion at https://github.com/mozilla/pdf.js/issues/9456, it seems the `cancel()` method from pdf.js is unreliable.