### PR TITLE
Add example that consumes pdf from a protected REST endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,14 +282,14 @@ export default {
 ##### Example - consume pdf from secured REST endpoint with next, previous, print and current page of total pages navigations
  ```
  <template>
-  <div class="pdfviewer-container">
-    <div id="menuBarDiv">
+  <div>
+    <div>
       <button @click="previousPage">Prev</button>
       <p style="font-weight:bold;font-size:14px;display:inline;">{{page}} of {{numPages}} </p>
       <button @click="nextPage">Next</button>
       <button @click="$refs.pdf.print()">Print</button>
     </div>
-    <div id="pdfContainerDiv">
+    <div>
       <div style="width: 100%;">
 	     <pdf :src="pdfContent"
           :page="page"
@@ -322,10 +322,7 @@ export default {
   mounted() {
     var self = this;
 
-	 /*
-	  * Make use of axios to make ajax request to a secured REST endpoint that returns
-	  * PDF as octet stream.
-	  */
+    //Use axios library to make ajax call to REST endpoint that returns pdf as octet stream
     const authHeader = "Bearer yourAccessTokenGoesHere";
 
     axios({
@@ -358,26 +355,6 @@ export default {
   }
 }
 </script>
-
-<style>
-  body {
-    background-color: #808080;
-    margin: 0;
-    padding: 0;
-  }
-  #pdfviewer-container {
-    overflow: auto;
-    position: absolute;
-    width: 100%;
-    height: 150%;
-  }
-  #menuBarDiv {
-    margin-bottom: 1%;
-  }
-  #pdfContainerDiv {
-    margin: 2%;
-  }
-</style>
  ```
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+
+
 # vue-pdf
 vue.js pdf viewer
 
@@ -219,8 +221,6 @@ export default {
 
 </script>
 ```
-
-
 ##### Example - complete
 ```
 <template>
@@ -278,6 +278,107 @@ export default {
 }
 </script>
 ```
+
+##### Example - consume pdf from secured REST endpoint with next, previous, print and current page of total pages navigations
+ ```
+ <template>
+  <div class="pdfviewer-container">
+    <div id="menuBarDiv">
+      <button @click="previousPage">Prev</button>
+      <p style="font-weight:bold;font-size:14px;display:inline;">{{page}} of {{numPages}} </p>
+      <button @click="nextPage">Next</button>
+      <button @click="$refs.pdf.print()">Print</button>
+    </div>
+    <div id="pdfContainerDiv">
+      <div style="width: 100%;">
+	     <pdf :src="pdfContent"
+          :page="page"
+	      @page-loaded="currentPage = $event"
+          @error="error"
+          @num-pages="numPages = $event"
+          ref="pdf">
+        </pdf>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import pdf from 'vue-pdf'
+import axios from 'axios'  //library to make ajax request below
+
+export default {
+  data() {
+    return {
+      pdfContent: null,
+      numPages: 0,
+      page:1,
+      loadedRatio: 1
+    }
+  },
+  components: {
+    pdf: pdf
+  },
+  mounted() {
+    var self = this;
+
+	 /*
+	  * Make use of axios to make ajax request to a secured REST endpoint that returns
+	  * PDF as octet stream.
+	  */
+    const authHeader = "Bearer yourAccessTokenGoesHere";
+
+    axios({
+      url: 'http://localhost:8080/sample/pdf',
+      method: 'GET',
+      responseType: 'blob',
+      headers: {
+        'Authorization': authHeader,
+      },
+    }).then((response) => {
+      var blob = new Blob([response.data], {type: 'application/pdf'});
+      var blobURL = window.URL.createObjectURL(blob);
+      self.pdfContent = blobURL;
+    });
+  },
+  methods: {
+    nextPage: function() {
+      //Go to next page if any
+      if(this.page < this.numPages)
+        this.page++;
+    },
+    previousPage: function() {
+      //Go to previous page if not already at page 1
+      if(this.page > 1)
+        this.page--;
+    },
+    error: function(err) {
+			console.log(err);
+		}
+  }
+}
+</script>
+
+<style>
+  body {
+    background-color: #808080;
+    margin: 0;
+    padding: 0;
+  }
+  #pdfviewer-container {
+    overflow: auto;
+    position: absolute;
+    width: 100%;
+    height: 150%;
+  }
+  #menuBarDiv {
+    margin-bottom: 1%;
+  }
+  #pdfContainerDiv {
+    margin: 2%;
+  }
+</style>
+ ```
 
 ## Credits
 [<img src="https://www.franck-freiburger.com/FF.png" width="16"> Franck Freiburger](https://www.franck-freiburger.com)


### PR DESCRIPTION
I used vue-pdf for my project where I was serving pdf from a REST endpoint as an octet stream protected by OAuth2 and I thought of contributing the solution back to the repo as it might help others who want to learn how to 

- How to add navigation buttons such as Next, Previous
- How to consume PDF from a secured REST endpoint 

Not sure if this PR can be considered as a contribution towards the issue #22 asking for tutorial.