### PR TITLE
Print PDF issue in Internet Explorer

### DIFF
--- a/src/pdfjsWrapper.js
+++ b/src/pdfjsWrapper.js
@@ -159,7 +159,11 @@ export default function(PDFJS) {
 				.then(function() {
 
 					win.focus(); // Required for IE
-					win.print();
+					if (win.document.queryCommandSupported('print')) {
+						win.document.execCommand('print', false, null);
+						} else {
+						win.print();
+					  }
 					removeIframe();
 				})
 				.catch(function(err) {

--- a/src/pdfjsWrapper.js
+++ b/src/pdfjsWrapper.js
@@ -159,11 +159,7 @@ export default function(PDFJS) {
 				.then(function() {
 
 					win.focus(); // Required for IE
-					if (win.document.queryCommandSupported('print')) {
-						win.document.execCommand('print', false, null);
-						} else {
-						win.print();
-					  }
+					win.print();
 					removeIframe();
 				})
 				.catch(function(err) {


### PR DESCRIPTION
I was unable to print full PDF page in Internet Explorer 11, Right half of the page was broken and i was getting blank page after every page. I have fixed that issue now we can print full page without any break in the right side of the page and no more blank pages.