### PR TITLE
For issue #75 "PDF opens in rotated orientation, but only in vuepdf (…

### DIFF
--- a/src/pdfjsWrapper.js
+++ b/src/pdfjsWrapper.js
@@ -188,8 +188,7 @@ export default function(PDFJS) {
 			if ( pdfPage === null )
 				return;
 
-			if ( rotate === undefined )
-				rotate = pdfPage.rotate;
+			rotate = (typeof pdfPage.rotate === 'undefined'? 0 : pdfPage.rotate) + (typeof rotate === 'undefined'? 0 : rotate);
 
 			var scale = canvasElt.offsetWidth / pdfPage.getViewport(1).width * (window.devicePixelRatio || 1);
 			var viewport = pdfPage.getViewport(scale, rotate);

--- a/src/pdfjsWrapper.js
+++ b/src/pdfjsWrapper.js
@@ -188,7 +188,7 @@ export default function(PDFJS) {
 			if ( pdfPage === null )
 				return;
 
-			rotate = (typeof pdfPage.rotate === 'undefined'? 0 : pdfPage.rotate) + (typeof rotate === 'undefined'? 0 : rotate);
+			rotate = (pdfPage.rotate === undefined ? 0 : pdfPage.rotate) + (rotate === undefined ? 0 : rotate);
 
 			var scale = canvasElt.offsetWidth / pdfPage.getViewport(1).width * (window.devicePixelRatio || 1);
 			var viewport = pdfPage.getViewport(scale, rotate);


### PR DESCRIPTION
…does not happen in PDF.JS)"

- Changed rotation to be additive (internal pdf rotation + vuepdf rotation input) so that
internal pdf rotation is respected.
This fixes issues where internal rotation of pdf is not zero (0) degrees and we still want to pass
our own rotation to VuePdf.