### PR TITLE
fix ie11 syntax error

### DIFF
--- a/src/pdfjsWrapper.js
+++ b/src/pdfjsWrapper.js
@@ -199,7 +199,7 @@ export default function(PDFJS) {
 			rotate = (pdfPage.rotate === undefined ? 0 : pdfPage.rotate) + (rotate === undefined ? 0 : rotate);
 
 			var scale = canvasElt.offsetWidth / pdfPage.getViewport({ scale: 1 }).width * (window.devicePixelRatio || 1);
-			var viewport = pdfPage.getViewport({ scale, rotation:rotate });
+			var viewport = pdfPage.getViewport({ scale: scale, rotation:rotate });
 
 			emitEvent('page-size', viewport.width, viewport.height);
 


### PR DESCRIPTION
```
var viewport = pdfPage.getViewport({ scale, rotation:rotate });
```

IE not support **Property Shorthand**, this will throw  syntax error