### PR TITLE
Big bug! Auto rotate wrong! Solved~

### DIFF
--- a/src/pdfjsWrapper.js
+++ b/src/pdfjsWrapper.js
@@ -196,10 +196,10 @@ export default function(PDFJS) {
 			if ( pdfPage === null )
 				return;
 
-			rotate = (pdfPage.rotate === undefined ? 0 : pdfPage.rotate) + (rotate === undefined ? 0 : rotate);
+			var pageRotate = (pdfPage.rotate === undefined ? 0 : pdfPage.rotate) + (rotate === undefined ? 0 : rotate);
 
 			var scale = canvasElt.offsetWidth / pdfPage.getViewport({ scale: 1 }).width * (window.devicePixelRatio || 1);
-			var viewport = pdfPage.getViewport({ scale, rotation:rotate });
+			var viewport = pdfPage.getViewport({ scale, rotation:pageRotate });
 
 			emitEvent('page-size', viewport.width, viewport.height);
 


### PR DESCRIPTION
Big bug!
The rotate variable will be overloaded when the loop running in the renderPage function.

Please test it carefully, use 0 degree PDF, 90 degree PDF, 180 degree PDF, 270 degree PDF respectively!

Please update it quickly on npm release! Thanks very very much!