### PR TITLE
fix  display multiple pages example

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ export default {
 	},
 	mounted() {
 
-		this.src.then(pdf => {
+		this.src.promise.then(pdf => {
 
 			this.numPages = pdf.numPages;
 		});


### PR DESCRIPTION
The pdf.js wraps the loadingTask object;
[https://mozilla.github.io/pdf.js/examples/](https://mozilla.github.io/pdf.js/examples/)
```
var loadingTask = pdfjsLib.getDocument('helloworld.pdf');
loadingTask.promise.then(function(pdf) {
  // you can now use *pdf* here
});
```

If you do not add Promise, you will get the following error:
```
TypeError: this.src.then is not a function
```