### PR TITLE
Also emit scale when emitting page-size event

### DIFF
--- a/src/pdfjsWrapper.js
+++ b/src/pdfjsWrapper.js
@@ -202,7 +202,7 @@ export default function(PDFJS) {
 			var scale = canvasElt.offsetWidth / pdfPage.getViewport({ scale: 1 }).width * (window.devicePixelRatio || 1);
 			var viewport = pdfPage.getViewport({ scale: scale, rotation:pageRotate });
 
-			emitEvent('page-size', viewport.width, viewport.height);
+			emitEvent('page-size', viewport.width, viewport.height, scale);
 
 			canvasElt.width = viewport.width;
 			canvasElt.height = viewport.height;


### PR DESCRIPTION
I need to know the physical size of the PDF page. I noticed you're already emitting a page-size event with the viewport size. If it also emitted the scale, I could easily compute it. Would you consider accepting this PR so I could get rid of my fork?