### PR TITLE
Fix annotation layer misalignment issue

### DIFF
--- a/src/pdfjsWrapper.js
+++ b/src/pdfjsWrapper.js
@@ -199,7 +199,7 @@ export default function(PDFJS) {
 
 			var pageRotate = (pdfPage.rotate === undefined ? 0 : pdfPage.rotate) + (rotate === undefined ? 0 : rotate);
 
-			var scale = canvasElt.offsetWidth / pdfPage.getViewport({ scale: 1 }).width * (window.devicePixelRatio || 1);
+			var scale = canvasElt.offsetWidth / pdfPage.getViewport({ scale: 1 }).width * 1;
 			var viewport = pdfPage.getViewport({ scale: scale, rotation:pageRotate });
 
 			emitEvent('page-size', viewport.width, viewport.height, scale);


### PR DESCRIPTION
Set ratio to 1. Any other value causes unexpected alignment issues of the annotation layer, specifically some instances in windows 10 google chrome. Tested on multiple devices, this fix has now issues.