### PR TITLE
Allow for the "withCredentials" option to be passed to pdfJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,18 @@ Triggered when an internal link is clicked
 
 ### Public static methods
 
-#### createLoadingTask(src)
+#### createLoadingTask(src[, options])
   * `src`: see `:src` prop  
+  * `options`: an object of options. 
   This function creates a PDFJS loading task that can be used and reused as `:src` property.  
   The loading task is a promise that resolves with the PDFJS pdf document that exposes the `numPages` property (see example below).
   
   **beware:** when the component is destroyed, the object returned by `createLoadingTask()` become invalid. 
+  
+  Supported options:
+  * onPassword: Callback that's called when a password protected PDF is being opened.
+  * onProgress: Callback return loading progress.
+  * withCredentials: Wheter or not to send cookies in the fetch request.
 
 
 ## Examples

--- a/src/pdfjsWrapper.js
+++ b/src/pdfjsWrapper.js
@@ -26,6 +26,9 @@ export default function(PDFJS) {
 		// source.pdfBug = true;
 		// source.stopAtErrors = true;
 
+		if ( options && options.withCredentials )
+			source.withCredentials = true;
+
 		var loadingTask = PDFJS.getDocument(source);
 		loadingTask.__PDFDocumentLoadingTask = true; // since PDFDocumentLoadingTask is not public
 

--- a/src/pdfjsWrapper.js
+++ b/src/pdfjsWrapper.js
@@ -27,7 +27,7 @@ export default function(PDFJS) {
 		// source.stopAtErrors = true;
 
 		if ( options && options.withCredentials )
-			source.withCredentials = true;
+			source.withCredentials = options.withCredentials;
 
 		var loadingTask = PDFJS.getDocument(source);
 		loadingTask.__PDFDocumentLoadingTask = true; // since PDFDocumentLoadingTask is not public


### PR DESCRIPTION
pdfJS uses the "fetch" API to download the PDF. By default, it does not send cookies in cross-site scenarios. With this setting, cookies are always sent.