### PR TITLE
Fix use cdn worker init error

### DIFF
--- a/src/vuePdfNoSss.vue
+++ b/src/vuePdfNoSss.vue
@@ -10,7 +10,7 @@
 
 		if ( typeof window !== 'undefined' && 'Worker' in window && navigator.appVersion.indexOf('MSIE 10') === -1 ) {
 
-			var PdfjsWorker = require('worker-loader!pdfjs-dist/es5/build/pdf.worker.js');
+			var PdfjsWorker = require('worker-loader?inline!pdfjs-dist/es5/build/pdf.worker.js');
 			PDFJS.GlobalWorkerOptions.workerPort = new PdfjsWorker();
 		}
 


### PR DESCRIPTION
Fix `Failed to construct 'Worker'` error when cdn uses other domain names