### PR TITLE
338 - Fix render method missing catch statement on render failure

### DIFF
--- a/src/pdfjsWrapper.js
+++ b/src/pdfjsWrapper.js
@@ -215,7 +215,7 @@ export default function(PDFJS) {
 			pdfRender = pdfPage.render({
 				canvasContext: canvasElt.getContext('2d'),
 				viewport: viewport
-			});
+			}).catch(function(err) { return err });
 
 			annotationLayerElt.style.visibility = 'hidden';
 			clearAnnotations();


### PR DESCRIPTION
This solves the issue https://github.com/FranckFreiburger/vue-pdf/issues/338

There are cases when the document loads but pdfPage.render method triggers an error as pdfPage is undefined, not having the catch statement triggers a console error.

@FranckFreiburger given you are not maintaining this package since 5-4 months I'm wondering if you can consider requesting some help and include more maintainers.