### PR TITLE
render.cancel() doesn't return a promise

### DIFF
--- a/src/pdfjsWrapper.js
+++ b/src/pdfjsWrapper.js
@@ -193,9 +193,12 @@ export default function(PDFJS) {
 				if ( canceling )
 					return;
 				canceling = true;
-				pdfRender.cancel().catch(function(err) {
+
+        try {
+          pdfRender.cancel();
+        } catch(err) {
 					emitEvent('error', err);
-				});
+				}
 				return;
 			}
 


### PR DESCRIPTION
vue-pdf some times breaks because when canceling is expecting for cancel to return a Promise which doesn't and thats the reason for console error and empty views