### PR TITLE
Render on component load Cannot read properties of undefined (reading 'catch')

### DIFF
--- a/src/pdfjsWrapper.js
+++ b/src/pdfjsWrapper.js
@@ -190,9 +190,10 @@ export default function(PDFJS) {
 		this.renderPage = function(rotate) {
 			if ( pdfRender !== null ) {
 
+				canceling = true;
 				if ( canceling )
 					return;
-				canceling = true;
+				// canceling = true;
 				pdfRender.cancel().catch(function(err) {
 					emitEvent('error', err);
 				});


### PR DESCRIPTION
Using version 4.3.0, add pdf src to the component to render `Typeerror: cannot read properties of undefined (reading'catch')`, but this does not affect the normal use of the component. Locate the error, and the error is displayed in `pdfRender.cancel().catch(function(err) {
         emitEvent('error', err);
});` 
Just put `canceling = true;` in front of  `if ( canceling )`，the component will not render this error.