### PR TITLE
Cannot read properties of undefined (reading 'catch')

### DIFF
--- a/src/pdfjsWrapper.js
+++ b/src/pdfjsWrapper.js
@@ -193,9 +193,11 @@ export default function(PDFJS) {
 				if ( canceling )
 					return;
 				canceling = true;
-				pdfRender.cancel().catch(function(err) {
+				try {
+					pdfRender.cancel()	
+				} catch (err) {
 					emitEvent('error', err);
-				});
+				}
 				return;
 			}
 


### PR DESCRIPTION
cancel() function doesn't seem to return a promise, so catch will result in an error

- https://github.com/FranckFreiburger/vue-pdf/commit/612cae27f33795ef2ca734d9675f4c6058f28d78

