### PR TITLE
chore(MPR-2143): add publish packages workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+name: Publish Packages
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: [self-hosted, sushi]
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::195845782233:role/GitHub-Actions-Role
+          role-session-name: mapit
+          aws-region: eu-west-1
+
+      - name: Login to AWS CodeArtifact
+        run: |
+          aws codeartifact login --tool npm --domain mapit-iot --repository mapit-repo --namespace mapit --domain-owner 195845782233
+
+      - name: Publish to AWS CodeArtifact
+        run: npm publish
+
+      - name: Summary
+        run: |
+          echo "## Published Package" >> $GITHUB_STEP_SUMMARY
+          node -e "const p=require('./package.json'); console.log('- ' + p.name + '@' + p.version)" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -3,12 +3,16 @@ vue.js pdf viewer is a package for Vue that enables you to display and view PDF'
 
 ## Install via NPM/Yarn
 ```bash
-npm install vue-pdf
+npm install mapit-iot/vue-pdf
 ```
 
 ```bash
-yarn add vue-pdf
+yarn add mapit-iot/vue-pdf
 ```
+
+## Fork Info
+Fork of [Franck Freiburger's vue-pdf](https://github.com/FranckFreiburger/vue-pdf) which appears to be abandonded.
+This release fixes a bug which throws the error: "TypeError: Cannot read properties of undefined (reading 'catch')". with the fix of [Tim Eckel](https://github.com/teckel12) -> https://github.com/teckel12/vue-pdf/pull/1/files
 
 ## Example - basic
 ```vue

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "vue-pdf",
-  "version": "4.2.0",
+  "name": "mapit-iot/vue-pdf",
+  "version": "4.2.1",
   "description": "vue.js pdf viewer",
   "main": "src/vuePdfNoSss.vue",
   "scripts": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/FranckFreiburger/vue-pdf.git"
+    "url": "git+https://github.com/mapit-iot/vue-pdf.git"
   },
   "keywords": [
     "vue.js",
@@ -16,9 +16,9 @@
   "author": "Franck FREIBURGER",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/FranckFreiburger/vue-pdf/issues"
+    "url": "https://github.com/mapit-iot/vue-pdf/issues"
   },
-  "homepage": "https://github.com/FranckFreiburger/vue-pdf#readme",
+  "homepage": "https://github.com/mapit-iot/vue-pdf#readme",
   "dependencies": {
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "loader-utils": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "mapit-iot/vue-pdf",
-  "version": "4.2.1",
+  "name": "@mapit/vue-pdf",
+  "version": "4.3.1",
   "description": "vue.js pdf viewer",
   "main": "src/vuePdfNoSss.vue",
   "scripts": {},
@@ -15,10 +15,6 @@
   ],
   "author": "Franck FREIBURGER",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/mapit-iot/vue-pdf/issues"
-  },
-  "homepage": "https://github.com/mapit-iot/vue-pdf#readme",
   "dependencies": {
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "loader-utils": "^1.4.0",
@@ -26,6 +22,5 @@
     "worker-loader": "^2.0.0",
     "pdfjs-dist": "^2.5.207 <2.8.0",
     "vue-resize-sensor": "^2.0.0"
-  },
-  "peerDependencies": {}
+  }
 }

--- a/src/pdfjsWrapper.js
+++ b/src/pdfjsWrapper.js
@@ -193,7 +193,8 @@ export default function(PDFJS) {
 				if ( canceling )
 					return;
 				canceling = true;
-				pdfRender.cancel().catch(function(err) {
+				pdfRender.cancel();
+				pdfRender.promise.catch(function(err) {
 					emitEvent('error', err);
 				});
 				return;


### PR DESCRIPTION
Adds a GitHub Actions workflow to automatically publish the @mapit/vue-pdf package to AWS CodeArtifact when merging to master. This enables automated package publishing instead of manual npm publish steps.

[MPR-2143](https://mapitiot.atlassian.net/browse/MPR-2143)